### PR TITLE
Unnecessary dot before server.cjs causes error

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "concurrently  \"node .\\server.cjs\" \"vite\"",
+    "dev": "concurrently  \"node \\server.cjs\" \"vite\"",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },


### PR DESCRIPTION
When running `npm run dev` it logs:

```
[0] Error: Cannot find module '/home/giannis/stack-overflow-clone/.server.cjs'
[0]     at Module._resolveFilename (node:internal/modules/cjs/loader:1077:15)
[0]     at Module._load (node:internal/modules/cjs/loader:922:27)
[0]     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
[0]     at node:internal/main/run_main_module:23:47 {
[0]   code: 'MODULE_NOT_FOUND',
[0]   requireStack: []
[0] }
[0]
```

which means dot is unnecessary potentially?